### PR TITLE
biuld後にPuppeteerに必要なChromiumをインストールする設定の追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "scripts": {
         "build": "tsc",
         "start": "node dist/server.js",
-        "serve": "npm run build && npm run start"
+        "serve": "npm run build && npm run start",
+        "postbuild": "npx puppeteer browsers install chrome"
     },
     "dependencies": {
         "cors": "^2.8.5",


### PR DESCRIPTION
### errorMessage：src取得中にエラーが発生しました。
エラー: Chrome (ver. 138.0.7204.49)が見つかりません でした。これは、次のいずれかの場合に発生する可能性があります。

- スクリプトを実行する前にインストールを実行しなかった （例：`npx puppeteer browsers install chrome`）または
- キャッシュパス が正しく設定されていません( /opt/render/.cache/puppeteer )。